### PR TITLE
Avoiding callback hell while on the go with a flexible layout!

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -1450,7 +1450,7 @@ label.error {
   #post .inner {
     width: 100%;
     margin: 0;
-    padding: 10px 0px 
+    padding: 10px 0px;
     }
   .toggle-mode {
     right: 0;

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -1450,9 +1450,25 @@ label.error {
   #post .inner {
     width: 100%;
     margin: 0;
-    padding: 20px 0px 40px 0px;
+    padding: 10px 0px 
     }
   .toggle-mode {
     right: 0;
+    }
+  }
+
+  @media all and (max-width: 480px) {
+    .document .content-preview, .document .content {
+      width: 100%;
+      padding: 0;
+    }
+    .content-preview-wrapper {
+      padding-top: 0;
+    }
+    #container {
+      min-width: 100%;
+    }
+    .post-content {
+      padding: 20px 15px;
     }
   }


### PR DESCRIPTION
The site looked like this before in iOS:

![before](http://i.imgur.com/qWjN9.png)

couldn't zoom or read anything conveniently :(

now the layout is flexible for smaller screens and looks like this:

![after](http://i.imgur.com/kIYrI.png)

the code sections are scrollable too, but that wasn't me
