### PR TITLE
Update the function hoisting external source

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                             statusMessage.value = body
                           }
                       
-                      Note that the `function` declarations here are defined at the bottom of the file. This is thanks to [function hoisting](https://gist.github.com/maxogden/4bed247d9852de93c94c).
+                      Note that the `function` declarations here are defined at the bottom of the file. This is thanks to [function hoisting](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting).
                       
                       ## 2. Modularize
                       
@@ -225,7 +225,7 @@
                       ### Summary
                       
                       1. Don't nest functions. Give them names and place them at the top level of your program
-                      2. Use [function hoisting](https://gist.github.com/maxogden/4bed247d9852de93c94c) to your advantage to move functions 'below the fold'
+                      2. Use [function hoisting](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) to your advantage to move functions 'below the fold'
                       3. Handle **every single error** in every one of your callbacks. Use a linter like [standard](http://standardjs.com/) to help you with this.
                       4. Create reusable functions and place them in a module to reduce the cognitive load required to understand your code. Splitting your code into small pieces like this also helps you handle errors, write tests, forces you to create a stable and documented  public API for your code, and helps with refactoring.
                       


### PR DESCRIPTION
Going over the JS concepts, I found this project referenced by the [Mozilla website](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#chaining). It was a shame when I realized the [function hoisting link](https://gist.github.com/maxogden/4bed247d9852de93c94c) was broken. 

After not finding an eventual new URL of the gist by the same author, I update the source using the [Mozilla website source](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) about the same topic in order to give a valid source to the readers of this resource.